### PR TITLE
#165670437 Fix header token name for api docs

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -26,7 +26,7 @@ const swaggerDefinition = {
   securityDefinitions: {
     bearerAuth: {
       type: 'apiKey',
-      name: 'Authorization',
+      name: 'x-access-token',
       scheme: 'bearer',
       in: 'header',
     },


### PR DESCRIPTION
#### What does this PR do?
Modify header token

#### Description of Task to be completed?
Have api-docs accept token

#### How should this be manually tested?
After cloning the repo, cd into it and run `npm run dev`.
- Head over to the browser and type `localhost:5000/api/docs` in the url bar
- Try signing up to get a token
- Copy the token and paste in the authorized at the top of the docs.

#### Any background context you want to provide?
NA

#### What are the relevant pivotal tracker stories?
[#164982318](https://www.pivotaltracker.com/story/show/165670437/comments/202084425)
[Finishes #165670437]