### PR TITLE
bug(readme):fix api doc link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ ___
 ___
 
 ## API Information
-The API for this application is documented using [Swagger](https://surebanka.herokuapp.com/api-docs)
-The API endpoints are hosted on Heroku - [Banka](https://surebanka.herokuapp.com/api/v1)
+- The API for this application is documented using [Swagger](https://surebanka.herokuapp.com/api/docs)
+- The API endpoints are hosted on Heroku - [Banka](https://surebanka.herokuapp.com/api/v1)
 
 |METHOD  |DESCRIPTION                             |ENDPOINT                                            |
 |------- |----------------------------------------|----------------------------------------------------|


### PR DESCRIPTION
### What does this PR do?
Fix API Doc link from
`https://surebanka.herokuapp.com/api-docs` to
`https://surebanka.herokuapp.com/api/docs`

### How can this be manually tested?
To test the changes visit this [link](https://surebanka.herokuapp.com/api/docs)